### PR TITLE
forge config: Fix compiling issue on mac

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -1,9 +1,19 @@
+const fs = require('fs')
+const path = require('path')
 module.exports = {
   packagerConfig: {
     asar: true,
     icon: './images/logo.ico'
   },
   rebuildConfig: {},
+  hooks: {
+    packageAfterPrune: async (forgeConfig, buildPath, electronVersion, platform, arch) => {
+      if (platform === 'darwin') {
+        // we want to remove the problematic link on macOS 
+        fs.unlinkSync(path.join(buildPath, 'node_modules/register-scheme/build/node_gyp_bins/python3'))
+      }
+    }
+  },
   makers: [
     {
       name: '@electron-forge/maker-squirrel',


### PR DESCRIPTION
this fixes an error when compiling the app on macOS
```
An unhandled rejection has occurred inside Forge:
Error: /var/folders/9b/419m4hqs453_18_fftblwxhm0000gn/T/electron-packager/darwin-arm64/roblox-rpc-darwin-arm64-AXDf61/Electron.app/Contents/Resources/app/node_modules/register-scheme/build/node_gyp_bins/python3: file "../../../../../../../../../../../../../Library/Frameworks/Python.framework/Versions/3.8/bin/python3.8" links out of the package
```